### PR TITLE
Fix the boo/modeling test by disabling the session cache

### DIFF
--- a/iree/turbine/kernel/boo/conv_exports/launch.py
+++ b/iree/turbine/kernel/boo/conv_exports/launch.py
@@ -16,6 +16,7 @@ from ....support.logging import runtime_logger as logger
 __all__ = [
     "is_cache_enabled",
     "clear_cache_dir",
+    "ConvLaunchableRuntimeCache",
     "get_launchable",
     "set_boo_cache",
 ]
@@ -120,9 +121,6 @@ class ConvLaunchableRuntimeCache:
         self.cache_limit = cache_limit
         self.session_cache: OrderedDict[str, Launchable] = OrderedDict()
 
-    def set_cache_limit(self, new_cache_limit: int | None):
-        self.cache_limit = new_cache_limit
-
     def add_to_session_cache(self, key: str, launchable: Launchable):
         self.session_cache[key] = launchable
         self.session_cache.move_to_end(key)
@@ -136,13 +134,27 @@ class ConvLaunchableRuntimeCache:
         return self.session_cache.get(key, None)
 
     @staticmethod
-    def get_launchable_cache(cache_limit: int | None = None):
+    def get_launchable_cache():
         global _launchable_cache
         if "_launchable_cache" in globals():
-            _launchable_cache.set_cache_limit(cache_limit)
             return _launchable_cache
-        _launchable_cache = ConvLaunchableRuntimeCache(cache_limit)
+        _launchable_cache = ConvLaunchableRuntimeCache()
         return _launchable_cache
+
+    @staticmethod
+    def clear():
+        global _launchable_cache
+        if not "_launchable_cache" in globals():
+            return
+        _launchable_cache.session_cache.clear()
+
+    @staticmethod
+    def set_cache_limit(new_cache_limit: int | None):
+        global _launchable_cache
+        if "_launchable_cache" in globals():
+            _launchable_cache.cache_limit = new_cache_limit
+            return
+        _launchable_cache = ConvLaunchableRuntimeCache(new_cache_limit)
 
 
 def get_launchable(


### PR DESCRIPTION
I'm also adding calls to synchronize just in case, but this might not be necessary since we need to compile anyway. 