### PR TITLE
Cleanup and caching improvements for `Device` and `compile_standalone_kernel`

### DIFF
--- a/iree/turbine/runtime/invoke.py
+++ b/iree/turbine/runtime/invoke.py
@@ -43,20 +43,19 @@ def invoke_vm_function(
 
     if is_async:
         external_timepoint = device.setup_iree_action()
-        if device._device_interop.no_sync():
-            wait_fence = HalFence(0)
-            signal_fence = HalFence(0)
-
-            arg_list.push_ref(wait_fence)
-            arg_list.push_ref(signal_fence)
-        else:
+        if device.sync:
             wait_fence = HalFence.create_at(
                 device._main_timeline, device._main_timepoint - 1
             )
-            signal_fence = HalFence.create_at(device._main_timeline, device._main_timepoint)
+            signal_fence = HalFence.create_at(
+                device._main_timeline, device._main_timepoint
+            )
+        else:
+            wait_fence = HalFence(0)
+            signal_fence = HalFence(0)
 
-            arg_list.push_ref(wait_fence)
-            arg_list.push_ref(signal_fence)
+        arg_list.push_ref(wait_fence)
+        arg_list.push_ref(signal_fence)
 
     # Invoke.
     start = timer()

--- a/tests/runtime/device_stream_test.py
+++ b/tests/runtime/device_stream_test.py
@@ -1,0 +1,86 @@
+# Copyright 2025 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+import pytest
+
+import torch
+
+from iree.turbine.runtime.device import get_device_from_torch
+from iree.turbine.ops.conv_fwd import conv_2d_nhwc_fhwc
+
+
+class DeviceStreamTest(unittest.TestCase):
+    def setUp(self):
+        if not torch.cuda.is_available():
+            return
+        self.stream0 = torch.cuda.current_stream(0)
+        self.stream1 = torch.cuda.Stream(0)
+        self.stream2 = torch.cuda.Stream(0)
+        print(self.stream0.cuda_stream)
+        print(self.stream0.stream_id)
+        print(self.stream1.cuda_stream)
+        print(self.stream1.stream_id)
+        print(self.stream2.cuda_stream)
+        print(self.stream2.stream_id)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires gpu.")
+    def testDeviceCreation(self):
+        d0 = get_device_from_torch(torch.device("cuda:0"))
+        with torch.cuda.stream(self.stream1):
+            d1 = get_device_from_torch(torch.device("cuda:0"))
+        with torch.cuda.stream(self.stream2):
+            d2 = get_device_from_torch(torch.device("cuda:0"))
+        self.assertEqual(d0._s.torch_stream, self.stream0.cuda_stream)
+        self.assertEqual(d1._s.torch_stream, self.stream1.cuda_stream)
+        self.assertEqual(d2._s.torch_stream, self.stream2.cuda_stream)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires gpu.")
+    def testEagerCustomOpMultiStream(self):
+        """This test uses a CustomOp to validate multi-stream invocations and Device-Host copy.
+        Heavier computations are used to ensure that GPU synchronization isn't trivialized by CPU overhead."""
+
+        torch_device = torch.device("cuda:0")
+        input0 = torch.ones(
+            [16, 2048, 2048, 16], dtype=torch.float32, device=torch_device
+        )
+        input1 = torch.ones([4, 16, 16, 16], dtype=torch.float32, device=torch_device)
+        input2 = torch.ones([3, 1, 1, 4], dtype=torch.float32, device=torch_device)
+        self.stream1.wait_stream(torch.cuda.current_stream(0))
+        # Do the computations once on the default stream to jit compile artifacts.
+        res0 = conv_2d_nhwc_fhwc(input0, input1, [1, 1], [1, 1])
+        _ = conv_2d_nhwc_fhwc(res0, input2, [1, 1], [1, 1])
+
+        for _ in range(20):
+            # Do first conv on stream 1
+            with torch.cuda.stream(self.stream1):
+                res0 = conv_2d_nhwc_fhwc(input0, input1, [1, 1], [1, 1])
+                ev = torch.cuda.Event()
+                ev.record(self.stream1)
+
+            input0.record_stream(self.stream1)
+            input1.record_stream(self.stream2)
+
+            # Do second conv on stream 2, waiting for stream 1's corresponding conv
+            with torch.cuda.stream(self.stream2):
+                ev.wait()
+                res = conv_2d_nhwc_fhwc(res0, input2, [1, 1], [1, 1])
+            res0.record_stream(self.stream2)
+            input2.record_stream(self.stream2)
+
+        # move the last result from each stream to host without blocking
+        with torch.cuda.stream(self.stream1):
+            cpu_last_result_1 = res0.to(device="cpu", non_blocking=True)
+        with torch.cuda.stream(self.stream2):
+            cpu_last_result_2 = res.to(device="cpu", non_blocking=True)
+
+        # validate the results match expectations
+        self.assertEqual(cpu_last_result_1[0, 0, 0, 0].item(), 16**3)
+        self.assertEqual(cpu_last_result_2[0, 0, 0, 0].item(), 4 * (16**3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. rework `no_sync` to `sync` and store this information for both `Device` and interop structs. 
2. retain code path for `sync` case, since `Device(uri)` inits won't be associated with a pytorch stream, and the old code path may be useful in future situations.
3. Makes sure to cache `device_by_torch_device` with keys as pairs `(torch_device, torch_stream_int)` instead of just the torch device. This ensures that devices created in separate stream contexts will not use the incorrect stream for iree kernel launches.
4. Improves the caching for `CustomOp` eager execution similar to `Launchable` internal caching. That is, cache `VmModule` per device type, and cache `VmContext, VmFunction` pairs by device instance. This way, recompilation only needs to occur per type of device, and creation of a new vm context happens per device instance (so the hal module uses the correct hal device, which has the correct hip stream). Maybe TODO(?): implement thread locks for these caches...
5. Adds a rather robust test of multi-stream execution.